### PR TITLE
Fix Supabase authentication integration

### DIFF
--- a/client/components/LoginForm.tsx
+++ b/client/components/LoginForm.tsx
@@ -20,12 +20,13 @@ export default function LoginForm() {
     setIsLoading(true);
 
     try {
-      const success = await login(email, password);
-      if (!success) {
-        setError("Email ou senha incorretos");
-      }
+      await login(email, password);
     } catch (err) {
-      setError("Erro ao fazer login. Tente novamente.");
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Erro ao fazer login. Tente novamente.");
+      }
     } finally {
       setIsLoading(false);
     }

--- a/client/components/UserManagement.tsx
+++ b/client/components/UserManagement.tsx
@@ -39,7 +39,7 @@ export default function UserManagement({ onUserCreated }: UserManagementProps) {
     name: '',
     email: '',
     password: '',
-    role: 'seller' as 'admin' | 'seller',
+    role: 'seller' as 'admin' | 'seller' | 'operator',
     status: 'active' as 'active' | 'inactive',
     permissions: [] as string[]
   });
@@ -354,6 +354,7 @@ export default function UserManagement({ onUserCreated }: UserManagementProps) {
                   <SelectContent>
                     <SelectItem value="admin">Administrador</SelectItem>
                     <SelectItem value="seller">Vendedor</SelectItem>
+                    <SelectItem value="operator">Operador</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/client/hooks/useAuth.ts
+++ b/client/hooks/useAuth.ts
@@ -1,6 +1,7 @@
-import { useState, useEffect, createContext, useContext } from 'react';
+import { useState, useEffect, useCallback, createContext, useContext } from 'react';
+import type { User as SupabaseAuthUser } from '@supabase/supabase-js';
 import { AuthUser, AuthState } from '@/types/auth';
-import { useSupabase, User } from './useSupabase';
+import { supabase } from '@/lib/supabase';
 
 interface AuthContextType extends AuthState {
   login: (email: string, password: string) => Promise<boolean>;
@@ -25,64 +26,165 @@ export const useAuthProvider = (): AuthContextType => {
     isLoading: true
   });
 
-  const { getUsers } = useSupabase();
+  const isBrowser = typeof window !== 'undefined';
 
-  useEffect(() => {
-    checkAuthState();
+  const buildAuthUser = useCallback(async (supabaseUser: SupabaseAuthUser): Promise<AuthUser> => {
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select('id, name, email, role, permissions')
+        .eq('id', supabaseUser.id)
+        .single();
+
+      if (error) {
+        console.warn('Falha ao carregar perfil do usuário no Supabase:', error.message);
+      }
+
+      const profile = data ?? null;
+
+      return {
+        id: profile?.id ?? supabaseUser.id,
+        name:
+          profile?.name ??
+          (supabaseUser.user_metadata?.full_name as string | undefined) ??
+          supabaseUser.email ??
+          'Usuário',
+        email: profile?.email ?? supabaseUser.email ?? '',
+        role: (profile?.role ?? 'seller') as AuthUser['role'],
+        permissions: Array.isArray(profile?.permissions) ? profile.permissions : []
+      };
+    } catch (error) {
+      console.error('Erro ao montar usuário autenticado:', error);
+      return {
+        id: supabaseUser.id,
+        name:
+          (supabaseUser.user_metadata?.full_name as string | undefined) ??
+          supabaseUser.email ??
+          'Usuário',
+        email: supabaseUser.email ?? '',
+        role: 'seller',
+        permissions: []
+      };
+    }
   }, []);
 
-  const checkAuthState = async () => {
-    // Check for stored auth
-    const storedUser = localStorage.getItem('bioboxsys_user');
-    if (storedUser) {
-      try {
-        const user = JSON.parse(storedUser);
-        setAuthState({
-          user,
-          isAuthenticated: true,
-          isLoading: false
-        });
-      } catch {
-        localStorage.removeItem('bioboxsys_user');
-        setAuthState(prev => ({ ...prev, isLoading: false }));
-      }
+  const persistAuthUser = useCallback((user: AuthUser | null) => {
+    if (!isBrowser) return;
+    if (user) {
+      localStorage.setItem('bioboxsys_user', JSON.stringify(user));
     } else {
-      setAuthState(prev => ({ ...prev, isLoading: false }));
+      localStorage.removeItem('bioboxsys_user');
     }
-  };
+  }, [isBrowser]);
 
-  const login = async (email: string, password: string): Promise<boolean> => {
+  const checkAuthState = useCallback(async () => {
+    setAuthState(prev => ({ ...prev, isLoading: true }));
     try {
-      // Get users from Supabase or fallback
-      const users = await getUsers();
-      const user = users.find(u => u.email === email);
-      
-      if (user && password === 'password') { // Simple password check for demo
-        const authUser: AuthUser = {
-          id: user.id,
-          name: user.name,
-          email: user.email,
-          role: user.role,
-          permissions: user.permissions
-        };
+      const {
+        data: { session }
+      } = await supabase.auth.getSession();
 
-        localStorage.setItem('bioboxsys_user', JSON.stringify(authUser));
+      if (session?.user) {
+        const authUser = await buildAuthUser(session.user);
+        persistAuthUser(authUser);
         setAuthState({
           user: authUser,
           isAuthenticated: true,
           isLoading: false
         });
-        return true;
+        return;
       }
-      return false;
+
+      const storedUser = isBrowser ? localStorage.getItem('bioboxsys_user') : null;
+      if (storedUser) {
+        const user = JSON.parse(storedUser) as AuthUser;
+        setAuthState({
+          user,
+          isAuthenticated: true,
+          isLoading: false
+        });
+        return;
+      }
+
+      setAuthState({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false
+      });
+    } catch (error) {
+      console.error('Erro ao verificar estado de autenticação:', error);
+      setAuthState({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false
+      });
+    }
+  }, [buildAuthUser, isBrowser, persistAuthUser]);
+
+  useEffect(() => {
+    void checkAuthState();
+
+    const {
+      data: { subscription }
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
+      if (session?.user) {
+        const authUser = await buildAuthUser(session.user);
+        persistAuthUser(authUser);
+        setAuthState({
+          user: authUser,
+          isAuthenticated: true,
+          isLoading: false
+        });
+      } else {
+        persistAuthUser(null);
+        setAuthState({
+          user: null,
+          isAuthenticated: false,
+          isLoading: false
+        });
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [buildAuthUser, checkAuthState, persistAuthUser]);
+
+  const login = async (email: string, password: string): Promise<boolean> => {
+    try {
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email,
+        password
+      });
+
+      if (error || !data.user) {
+        const message = error?.message ?? 'Credenciais inválidas';
+        console.error('Erro ao realizar login:', message);
+        throw new Error(message);
+      }
+
+      const authUser = await buildAuthUser(data.user);
+      persistAuthUser(authUser);
+      setAuthState({
+        user: authUser,
+        isAuthenticated: true,
+        isLoading: false
+      });
+      return true;
     } catch (error) {
       console.error('Erro no login:', error);
-      return false;
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('Não foi possível realizar o login.');
     }
   };
 
   const logout = () => {
-    localStorage.removeItem('bioboxsys_user');
+    supabase.auth.signOut().catch(error => {
+      console.error('Erro ao encerrar sessão:', error);
+    });
+    persistAuthUser(null);
     setAuthState({
       user: null,
       isAuthenticated: false,
@@ -93,7 +195,7 @@ export const useAuthProvider = (): AuthContextType => {
   const hasPermission = (module: string, action: string): boolean => {
     if (!authState.user) return false;
     if (authState.user.role === 'admin') return true;
-    
+
     // Check specific permissions
     const permission = `${module}:${action}`;
     return authState.user.permissions.includes(permission) || authState.user.permissions.includes('all');

--- a/client/lib/supabase.ts
+++ b/client/lib/supabase.ts
@@ -1,7 +1,11 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = 'https://lwfbuimpodmbtosakfsf.supabase.co'
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx3ZmJ1aW1wb2RtYnRvc2FrZnNmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc5NDA0MjksImV4cCI6MjA3MzUxNjQyOX0.gz90-RYiMC5PaIMPfkAMhOEsCPaospA4IbeUyhKIPqQ'
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase URL and anon key must be provided')
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 

--- a/client/types/auth.ts
+++ b/client/types/auth.ts
@@ -2,7 +2,7 @@ export interface AuthUser {
   id: string;
   name: string;
   email: string;
-  role: 'admin' | 'seller';
+  role: 'admin' | 'seller' | 'operator';
   permissions: string[];
 }
 

--- a/client/types/user.ts
+++ b/client/types/user.ts
@@ -3,7 +3,7 @@ export interface User {
   name: string;
   email: string;
   password?: string;
-  role: 'admin' | 'seller';
+  role: 'admin' | 'seller' | 'operator';
   permissions: Permission[];
   status: 'active' | 'inactive';
   createdAt: Date;
@@ -81,6 +81,10 @@ export const rolePermissions = {
   seller: [
     defaultPermissions.find(p => p.id === 'orders-full')!,
     defaultPermissions.find(p => p.id === 'customers-full')!
+  ],
+  operator: [
+    defaultPermissions.find(p => p.id === 'production-view')!,
+    defaultPermissions.find(p => p.id === 'production-manage')!
   ]
 };
 


### PR DESCRIPTION
## Summary
- read Supabase credentials from Vite environment variables and guard against missing configuration
- replace the mock login flow with Supabase auth session management and improved error handling
- align user role typings with the database schema, including operator support in management UI

## Testing
- `pnpm typecheck` *(fails: existing issues in BarcodeGenerator.tsx, ProductionCalendar.tsx, ProductionReport.tsx and Orders.backup.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68caff33f1bc8332a72c107d7a7d0163